### PR TITLE
copy default values into bvconfig.properties

### DIFF
--- a/SEOIntegration/examples/java/src/main/resources/bvconfig.properties
+++ b/SEOIntegration/examples/java/src/main/resources/bvconfig.properties
@@ -30,3 +30,21 @@ storiesIntegrationScript=\
 </script>
 
 version=${project.version}
+
+
+################
+#
+# The following properties are also defined and documented in bvclient.properties where they're meant to be modified,
+# but they're included here to define reasonable defaults in case the client cannot create that file and just needs
+# to override some properties via the Java API.
+#
+# Note that deploymentZoneId and cloudKey are not included and MUST be defined by the client.
+#
+################
+
+loadSEOFilesLocally=false
+localSEOFileRoot=
+connectTimeout=1000
+socketTimeout=1000
+includeDisplayIntegrationCode=false
+botDetection=true


### PR DESCRIPTION
 This change allows client to use the SDK without creating a properties file.
