### PR TITLE
CCS-2585 removed page number from payload

### DIFF
--- a/SEOIntegration/examples/php/bvseosdk.php
+++ b/SEOIntegration/examples/php/bvseosdk.php
@@ -182,8 +182,7 @@ class Base{
         // replace tokens for pagination URLs with page_url
         $seo_content = $this->_replaceTokens($seo_content);
 
-        $pay_load = $page_number;
-        $pay_load .= $seo_content;
+        $pay_load = $seo_content;
 
         return $pay_load;
     }


### PR DESCRIPTION
CCS-2585 removed page number from payload, so it doesn’t get displayed
on the page
