### PR TITLE
Update ExampleLocalProviderFeed.xml

### DIFF
--- a/LocalProviderFeed/ExampleLocalProviderFeed.xml
+++ b/LocalProviderFeed/ExampleLocalProviderFeed.xml
@@ -78,7 +78,7 @@
                 <City>San Francisco</City>
                 <StateProvince>CA</StateProvince>
                 <PostalCode>94104</PostalCode>
-                <Country>USA</Country>
+                <Country>US</Country>
                 <BusinessPhone>(415) 555 1234</BusinessPhone>
                 <AlternatePhone>415-555-2345</AlternatePhone>
             </ContactInfo>


### PR DESCRIPTION
As per new policy, the <Country> value requires an ISO two-letter specification.
